### PR TITLE
#162555261 separate test db from the ireporter db

### DIFF
--- a/app/api/v2/models/db.py
+++ b/app/api/v2/models/db.py
@@ -2,15 +2,15 @@
 
 import os
 import psycopg2
+
+from instance.config import config
+
+environment = os.getenv('FLASK_ENV')
+database_url = config[environment].db_url
    
 class Db:
     def __init__(self):
-        self.con = psycopg2.connect(       
-            dbname = 'Crud',
-            user = 'postgres',
-            host = 'localhost',
-            password = '6398litein'
-        )
+        self.con = psycopg2.connect(database_url)
         self.cur = self.con.cursor()
 
         

--- a/instance/config.py
+++ b/instance/config.py
@@ -8,11 +8,13 @@ class Config:
 class DevelopmentConfig(Config):
     """Configurations for the development environment"""
     DEBUG = True
+    db_url ="host=localhost user=postgres password=6398litein dbname=Crud"
+
 
 class TestingConfig(Config):
     """configuration for the testing environment"""
     DEBUG = True
-
+    db_url = "host=localhost user=postgres password=6398litein dbname=testing_db"
 class ProductionConfig(Config):
     """configuration for the production environment"""
     DEBUG = False


### PR DESCRIPTION
__What does this PR do?__
This PR separates the development database from the test database

__Description of tasks to be completed__
- create  a test database
- create a development database
- set the database urls in the respective config environments

__How should this be manually tested__
 - clone the repo
 - create a virtual environment
- create a two database with PostgreSQL, testing_db, and ireporter_db
- export The FLASK_ENV to either testing or development,
- Run pytest to test the testing_db
- Run the server to and head to postman to test the ireporter_db

__Relevant PT stories__
#162555261