### PR TITLE
#162683617 user can only edit their own location

### DIFF
--- a/app/api/v2/views/incident.py
+++ b/app/api/v2/views/incident.py
@@ -158,6 +158,12 @@ class UpdateLocation(Resource, Incidents):
         if not target:
             return {'message': 'Incident does not exist'}, 404
 
+        createdBy = target[2]
+        current_user = get_jwt_identity()
+        if createdBy != current_user:
+            return {"error":
+                    "Not allowed to edit a location you din't create"}, 405
+
         if target[5] != 'Draft':
             return {"message": "You cant change location for this intervention\
              its status is changed"}, 204
@@ -211,6 +217,11 @@ class UpdateComment(Resource, Incidents):
         if not target:
             return {'message': 'Incident does not exist'}, 404
 
+        createdBy = target[2]
+        current_user = get_jwt_identity()
+        if createdBy != current_user:
+            return {"error":
+                    "Not allowed to edit a comment you din't create"}, 405
         status = target[5]
         if status != 'Draft':
             return {"message": "You cant change the comment for this\


### PR DESCRIPTION
__What does this PR do?__
Restricts a user to edit only their own location

Description of tasks to be completed?
compare the logged in user with the created by value of an incident if they are equal allow update if not send an error message

How should this be manually tested?

clone the repo
create a virtualenv and activate it
install all the projects requirements by running pip install -r requirements.txt
Run the test pytest
Test the endpoints using postman
Relevant PT stories
#162683617