### PR TITLE
#1626885 user cannot delete an incident they did not create

### DIFF
--- a/app/api/v2/views/incident.py
+++ b/app/api/v2/views/incident.py
@@ -117,6 +117,13 @@ class AnIncident(Resource, Incidents):
             return {
                 'message': 'Incident with given id {} does not exist'
                 .format(incident_id)}, 404
+
+        createdBy = incident[2]
+        current_user = get_jwt_identity()
+        if createdBy != current_user:
+            return {"error":
+                    "Not allowed to edit a comment you din't create"}, 405
+                    
         self.delete_incident(incident_id)
         return {
             'status': 200,


### PR DESCRIPTION
__What does this PR do?__
Restricts a user from deleting an incident they did not create

__Description of tasks to be completed__
-  compare the current logged in user with the createdby attribute of an incident if they are equal allow a delete if not restrict

__How should this be manually tested?__
- clone the repo
- create a virtualenv and activate it
- install all the projects requirements by running `pip install -r requiremets.txt`
- run the tests
- run the server and test the endpoints using postman

__Relevant PT stories__
#1626885 